### PR TITLE
Updating  DBRef for mongoose 4.x

### DIFF
--- a/lib/types/dbref.js
+++ b/lib/types/dbref.js
@@ -57,10 +57,11 @@ exports.loadType = function (mongoose) {
   // The native type used for storage
   var versionSuperior = parseInt(mongoose.version.split('.')[0])
   var dbref;
-  if(versionSuperior && versionSuperior>=4)
+  if(versionSuperior && versionSuperior>=4){
   	dbref = mongoose.mongo.DBRef;
-  else
+  }else{
 	dbref = mongoose.mongo.BSONPure.DBRef
+  }
   
 
   // Constructor for schema type

--- a/lib/types/dbref.js
+++ b/lib/types/dbref.js
@@ -55,7 +55,11 @@ exports.loadType = function (mongoose) {
   var CastError = SchemaType.CastError;
 
   // The native type used for storage
+  var versionSuperior = parseInt(mongoose.version.split('.')[0])
   var dbref = mongoose.mongo.BSONPure.DBRef;
+  if(versionSuperior && versionSuperior>=4)
+  	dbref = mongoose.mongo.DBRef;
+  
 
   // Constructor for schema type
   function DBRef (value, options) {

--- a/lib/types/dbref.js
+++ b/lib/types/dbref.js
@@ -56,9 +56,11 @@ exports.loadType = function (mongoose) {
 
   // The native type used for storage
   var versionSuperior = parseInt(mongoose.version.split('.')[0])
-  var dbref = mongoose.mongo.BSONPure.DBRef;
+  var dbref;
   if(versionSuperior && versionSuperior>=4)
   	dbref = mongoose.mongo.DBRef;
+  else
+	dbref = mongoose.mongo.BSONPure.DBRef
   
 
   // Constructor for schema type


### PR DESCRIPTION
Mongoose 4.x does not use `BSONPure` variable
